### PR TITLE
inline parameters highlighting tweak

### DIFF
--- a/src/main/resources/gruvbox_dark_hard.xml
+++ b/src/main/resources/gruvbox_dark_hard.xml
@@ -618,6 +618,12 @@
     <option name="INLINE_PARAMETER_HINT">
       <value>
         <option name="FOREGROUND" value="fbf1c7" />
+        <option name="BACKGROUND" value="4d4d4d" />
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_HIGHLIGHTED">
+      <value>
+        <option name="FOREGROUND" value="fbf1c7" />
         <option name="BACKGROUND" value="8ec07c" />
       </value>
     </option>

--- a/src/main/resources/gruvbox_dark_hard.xml
+++ b/src/main/resources/gruvbox_dark_hard.xml
@@ -617,7 +617,7 @@
     </option>
     <option name="INLINE_PARAMETER_HINT">
       <value>
-        <option name="FOREGROUND" value="fbf1c7" />
+        <option name="FOREGROUND" value="acacac" />
         <option name="BACKGROUND" value="4d4d4d" />
       </value>
     </option>

--- a/src/main/resources/gruvbox_dark_medium.xml
+++ b/src/main/resources/gruvbox_dark_medium.xml
@@ -618,6 +618,12 @@
     <option name="INLINE_PARAMETER_HINT">
       <value>
         <option name="FOREGROUND" value="fbf1c7" />
+        <option name="BACKGROUND" value="4d4d4d" />
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_HIGHLIGHTED">
+      <value>
+        <option name="FOREGROUND" value="fbf1c7" />
         <option name="BACKGROUND" value="8ec07c" />
       </value>
     </option>

--- a/src/main/resources/gruvbox_dark_medium.xml
+++ b/src/main/resources/gruvbox_dark_medium.xml
@@ -617,7 +617,7 @@
     </option>
     <option name="INLINE_PARAMETER_HINT">
       <value>
-        <option name="FOREGROUND" value="fbf1c7" />
+        <option name="FOREGROUND" value="acacac" />
         <option name="BACKGROUND" value="4d4d4d" />
       </value>
     </option>

--- a/src/main/resources/gruvbox_dark_soft.xml
+++ b/src/main/resources/gruvbox_dark_soft.xml
@@ -618,6 +618,12 @@
     <option name="INLINE_PARAMETER_HINT">
       <value>
         <option name="FOREGROUND" value="fbf1c7" />
+        <option name="BACKGROUND" value="4d4d4d" />
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_HIGHLIGHTED">
+      <value>
+        <option name="FOREGROUND" value="fbf1c7" />
         <option name="BACKGROUND" value="8ec07c" />
       </value>
     </option>

--- a/src/main/resources/gruvbox_dark_soft.xml
+++ b/src/main/resources/gruvbox_dark_soft.xml
@@ -617,7 +617,7 @@
     </option>
     <option name="INLINE_PARAMETER_HINT">
       <value>
-        <option name="FOREGROUND" value="fbf1c7" />
+        <option name="FOREGROUND" value="acacac" />
         <option name="BACKGROUND" value="4d4d4d" />
       </value>
     </option>

--- a/src/main/resources/gruvbox_light_hard.xml
+++ b/src/main/resources/gruvbox_light_hard.xml
@@ -610,6 +610,12 @@
     <option name="INLINE_PARAMETER_HINT">
       <value>
         <option name="FOREGROUND" value="282828" />
+        <option name="BACKGROUND" value="cccccc" />
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_HIGHLIGHTED">
+      <value>
+        <option name="FOREGROUND" value="282828" />
         <option name="BACKGROUND" value="427b58" />
       </value>
     </option>

--- a/src/main/resources/gruvbox_light_medium.xml
+++ b/src/main/resources/gruvbox_light_medium.xml
@@ -610,6 +610,12 @@
     <option name="INLINE_PARAMETER_HINT">
       <value>
         <option name="FOREGROUND" value="282828" />
+        <option name="BACKGROUND" value="cccccc" />
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_HIGHLIGHTED">
+      <value>
+        <option name="FOREGROUND" value="282828" />
         <option name="BACKGROUND" value="427b58" />
       </value>
     </option>

--- a/src/main/resources/gruvbox_light_soft.xml
+++ b/src/main/resources/gruvbox_light_soft.xml
@@ -606,6 +606,12 @@
     <option name="INLINE_PARAMETER_HINT">
       <value>
         <option name="FOREGROUND" value="282828" />
+        <option name="BACKGROUND" value="cccccc" />
+      </value>
+    </option>
+    <option name="INLINE_PARAMETER_HINT_HIGHLIGHTED">
+      <value>
+        <option name="FOREGROUND" value="282828" />
         <option name="BACKGROUND" value="427b58" />
       </value>
     </option>


### PR DESCRIPTION
makes inline parameter hints use a more muted background, eg:
<img width="284" alt="image" src="https://github.com/lonre/gruvbox-intellij-theme/assets/661098/3955ef1b-9358-4128-ab14-04b83bc0cdc6">
vs
<img width="284" alt="image" src="https://github.com/lonre/gruvbox-intellij-theme/assets/661098/cec7af16-56f9-4edd-b9aa-c34c4cf3c3bd">
