### PR TITLE
Add rust specific options for function and method calls

### DIFF
--- a/src/main/resources/gruvbox_dark_hard.xml
+++ b/src/main/resources/gruvbox_dark_hard.xml
@@ -479,6 +479,11 @@
         <option name="FOREGROUND" value="d79921" />
       </value>
     </option>
+    <option name="DEFAULT_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="b8bb26" />
+      </value>
+    </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="611818" />
@@ -1055,5 +1060,7 @@
         <option name="FOREGROUND" value="83a598" />
       </value>
     </option>
+    <option name="org.rust.FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
+    <option name="org.rust.METHOD_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
   </attributes>
 </scheme>

--- a/src/main/resources/gruvbox_dark_medium.xml
+++ b/src/main/resources/gruvbox_dark_medium.xml
@@ -479,6 +479,11 @@
         <option name="FOREGROUND" value="d79921" />
       </value>
     </option>
+    <option name="DEFAULT_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="b8bb26" />
+      </value>
+    </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="611818" />
@@ -1055,5 +1060,7 @@
         <option name="FOREGROUND" value="83a598" />
       </value>
     </option>
+    <option name="org.rust.FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
+    <option name="org.rust.METHOD_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
   </attributes>
 </scheme>

--- a/src/main/resources/gruvbox_dark_soft.xml
+++ b/src/main/resources/gruvbox_dark_soft.xml
@@ -479,6 +479,11 @@
         <option name="FOREGROUND" value="d79921" />
       </value>
     </option>
+    <option name="DEFAULT_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="b8bb26" />
+      </value>
+    </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="611818" />
@@ -1055,5 +1060,7 @@
         <option name="FOREGROUND" value="83a598" />
       </value>
     </option>
+    <option name="org.rust.FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
+    <option name="org.rust.METHOD_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
   </attributes>
 </scheme>

--- a/src/main/resources/gruvbox_light_hard.xml
+++ b/src/main/resources/gruvbox_light_hard.xml
@@ -471,6 +471,11 @@
         <option name="FOREGROUND" value="d79921" />
       </value>
     </option>
+    <option name="DEFAULT_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="79740e" />
+      </value>
+    </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f9f5d7" />
@@ -1047,5 +1052,7 @@
         <option name="FOREGROUND" value="76678" />
       </value>
     </option>
+    <option name="org.rust.FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
+    <option name="org.rust.METHOD_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
   </attributes>
 </scheme>

--- a/src/main/resources/gruvbox_light_medium.xml
+++ b/src/main/resources/gruvbox_light_medium.xml
@@ -471,6 +471,11 @@
         <option name="FOREGROUND" value="d79921" />
       </value>
     </option>
+    <option name="DEFAULT_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="79740e" />
+      </value>
+    </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="fbf1c7" />
@@ -1047,5 +1052,7 @@
         <option name="FOREGROUND" value="76678" />
       </value>
     </option>
+    <option name="org.rust.FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
+    <option name="org.rust.METHOD_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
   </attributes>
 </scheme>

--- a/src/main/resources/gruvbox_light_soft.xml
+++ b/src/main/resources/gruvbox_light_soft.xml
@@ -467,6 +467,11 @@
         <option name="FOREGROUND" value="d79921" />
       </value>
     </option>
+    <option name="DEFAULT_FUNCTION_CALL">
+      <value>
+        <option name="FOREGROUND" value="79740e" />
+      </value>
+    </option>
     <option name="DELETED_TEXT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="f2e5bc" />
@@ -1043,5 +1048,7 @@
         <option name="FOREGROUND" value="76678" />
       </value>
     </option>
+    <option name="org.rust.FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
+    <option name="org.rust.METHOD_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
   </attributes>
 </scheme>


### PR DESCRIPTION
Hi!

Using RustRover I noticed that function and method calls were not using the right color.

It used to work fine with the Rust plugin, but it seems JetBrains changed it for RustRover:
- https://youtrack.jetbrains.com/issue/RUST-11892/Rust-Rover-Color-Scheme-for-Rust
- https://youtrack.jetbrains.com/issue/RUST-11895/Darcula-Contrast-theme-appears-different-in-RustRover

Let me know if I need to do more changes or update the changelog :smile: 